### PR TITLE
Update package metadata to include Vimeo, Spotify, and SoundCloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "framer-framer",
   "version": "1.1.0",
-  "description": "Universal embed resolver - extract embed HTML from any URL (YouTube, X/Twitter, TikTok, Facebook, Instagram, and more)",
+  "description": "Universal embed resolver - extract embed HTML from any URL (YouTube, X/Twitter, TikTok, Facebook, Instagram, Vimeo, Spotify, SoundCloud, and more)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -52,6 +52,9 @@
     "tiktok",
     "facebook",
     "instagram",
+    "vimeo",
+    "spotify",
+    "soundcloud",
     "ogp",
     "social-media"
   ]


### PR DESCRIPTION
## Summary
Updated the package.json metadata to reflect support for additional embed platforms: Vimeo, Spotify, and SoundCloud.

## Changes
- Updated package description to explicitly mention Vimeo, Spotify, and SoundCloud support alongside existing platforms
- Added three new keywords to the package.json keywords array: "vimeo", "spotify", and "soundcloud"

## Details
These metadata updates improve package discoverability and accurately represent the embed resolver's capabilities for users searching for support of these popular platforms.