### PR TITLE
fix(release): add react and vue packages to release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  "packages/core": "3.2.0"
+  "packages/core": "3.2.0",
+  "packages/react": "0.1.0",
+  "packages/vue": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,18 @@
       "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "include-component-in-release": false
+    },
+    "packages/react": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "react",
+      "bump-minor-pre-major": true
+    },
+    "packages/vue": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "vue",
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
release-please was only tracking packages/core, so @framer-framer/react
and @framer-framer/vue releases were not managed. Add both packages
to release-please-config.json and .release-please-manifest.json.