### PR TITLE
Refine release workflow tag pattern matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Updated the GitHub Actions release workflow to use a more precise regex pattern for matching version tags, ensuring only properly formatted semantic version tags trigger the release pipeline.

## Changes
- Modified the tag filter pattern in the release workflow from `"v*"` to `"v[0-9]*"`
  - The new pattern explicitly requires tags to start with 'v' followed by one or more digits
  - This prevents accidental matches on malformed or non-version tags (e.g., `v-beta`, `v-rc`)
  - Aligns with standard semantic versioning conventions (v1.0.0, v2.1.3, etc.)

## Implementation Details
The change uses a character class `[0-9]*` instead of the glob pattern `*`, which provides stricter validation at the GitHub Actions workflow level. This reduces the risk of unintended release triggers from tags that don't follow the expected version format.
