### PR TITLE
fix(ci): add --provenance flag for npm OIDC publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,5 +36,5 @@ jobs:
         run: npm run build -w packages/core
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: ${{ inputs.package-dir }}


### PR DESCRIPTION
## Summary
- npm Trusted Publishing (OIDC) requires the `--provenance` flag to generate and attach provenance attestations during publish
- Without this flag, `npm publish` fails with E404 because OIDC authentication is not initiated

## Changes
- Add `--provenance` to `npm publish` command in `release-publish.yml`

## Test plan
- [ ] マージ後、`v3.3.0` タグの release workflow を re-run して npm publish が成功することを確認
- [ ] npm パッケージページで provenance badge が表示されることを確認