### PR TITLE
fix: include root README.md in core npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ typings/
 # Build output
 dist/
 
+# Copied README for npm publish
+packages/core/README.md
+
 # Generated render-check page
 tools/.render-check.html

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "format": "biome format src test",
     "format:fix": "biome format --write src test",
     "ci": "npm run lint && npm run typecheck && npm run test && npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "cp ../../README.md . && npm run build"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",


### PR DESCRIPTION
## Summary
- `packages/core` に README.md がないため、npmjs.com でパッケージの説明が表示されない
- `prepublishOnly` でルートの README.md を `packages/core/` にコピーして npm tarball に含める
- コピーされた README.md は `.gitignore` で追跡対象外にする

## Test plan
- [ ] 次回リリース時に npm パッケージページで README が表示されることを確認