### PR TITLE
fix: revert react/vue versions to match actual git tags

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/core": "3.3.1",
-  "packages/react": "3.3.1",
-  "packages/vue": "3.3.1"
+  "packages/react": "3.2.1",
+  "packages/vue": "3.2.1"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@framer-framer/react",
-  "version": "3.3.1",
+  "version": "3.2.1",
   "description": "React component for framer-framer - embed any URL with <Embed url=\"...\" />",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@framer-framer/vue",
-  "version": "3.3.1",
+  "version": "3.2.1",
   "description": "Vue 3 embed component for framer-framer",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

- react/vue の manifest・package.json バージョンを実際の git タグ (`react-v3.2.1`, `vue-v3.2.1`) に一致する `3.2.1` に戻す
- 前回の `3.3.1` への変更は対応するタグが存在せず、release-please が壊れたバージョン (3.2.0 へのダウングレード) を生成してしまっていた
- `linked-versions` プラグインは既に追加済みなので、マージ後の release-please 再計算で全パッケージが `3.4.0` に統一される想定

## Test plan

- [ ] マージ後、release-please PR #110 が再生成され core/react/vue すべて `3.4.0` になることを確認