### PR TITLE
ci: force react/vue to release as 3.4.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,13 +19,15 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "component": "react",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "3.4.0"
     },
     "packages/vue": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "component": "vue",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "3.4.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- react と vue に `"release-as": "3.4.0"` を追加して、core と同じバージョンでリリースされるように強制

## 背景

`linked-versions` プラグインは core の `include-component-in-tag: false` により preconfigure 段階で core を認識できず、react/vue のみ 3.3.0 にリンクしていた。タグのプッシュも権限不足で不可。

`release-as` で直接バージョンを指定するのが最もシンプルな解決策。

## リリース後の対応

- [ ] リリース完了後、`release-as` を release-please-config.json から削除する