### PR TITLE
chore: remove release-as after 3.4.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,15 +19,13 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "component": "react",
-      "bump-minor-pre-major": true,
-      "release-as": "3.4.0"
+      "bump-minor-pre-major": true
     },
     "packages/vue": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "component": "vue",
-      "bump-minor-pre-major": true,
-      "release-as": "3.4.0"
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- react/vue から `release-as: "3.4.0"` を削除
- 3.4.0 リリース完了に伴うクリーンアップ
- 今後は通常の conventional commits ベースのバージョン計算に戻る